### PR TITLE
Ajout d'un lien vers le simulateur sur la page carbone

### DIFF
--- a/app/views/blog/budget-empreinte-carbone-c-est-quoi.md
+++ b/app/views/blog/budget-empreinte-carbone-c-est-quoi.md
@@ -187,4 +187,8 @@ L'action individuelle et l'action collective sont intimement liées, et toutes l
 
 **Alors, prêt à trouver vos 320 premiers kilos à perdre ?**
 
+**[Testez en avant première notre calculateur Nos Gestes Climat](/apps/climat)**.
+
+[![](https://imgur.com/6OIkPa0.png)](/apps/climat)
+
 ![Trois personnes, au lieu d'un seul individu, marchent dans une nature luxuriante bien qu'en contexte urbain, contrastant avec l'image d'introduction de l'article](https://images.unsplash.com/photo-1542113028-b526238297f1?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=975&q=80)

--- a/app/views/pages/impactcarbone.html.erb
+++ b/app/views/pages/impactcarbone.html.erb
@@ -16,7 +16,7 @@
 
 
         <div class="texts-banner">
-          <h1 class="banner_title-trans">Nos GEStes climat</h1>
+          <h1 class="banner_title-trans"><a href="/apps/climat">Nos GEStes climat</a></h1>
           <%#= render '/shared/search-bar' %>
           <p class="banner_subtitle">Aider vos utilisateurs à visualiser leur impact GES (Gaz à effet de serre) et à agir pour le réduire.</p>
 


### PR DESCRIPTION
Pour google, qui semble avoir du mal à le trouver pour l'instant (peu de sites font des liens vers la page /apps/climat)